### PR TITLE
[Service] Add telegram API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  
- ## [1.2.15] - 2021-04-08
+## [1.2.16] - 2021-04-09
+### Added
+- telethon
+- telegram api constants
+
+## [1.2.15] - 2021-04-08
 ### Updated
 - pyngrok version
 
- ## [1.2.14] - 2021-03-26
+## [1.2.14] - 2021-03-26
 ### Updated
 - Requirements
  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoBot-Services [1.2.15](https://github.com/Drakkar-Software/OctoBot-Services/tree/master/docs/CHANGELOG.md)
+# OctoBot-Services [1.2.16](https://github.com/Drakkar-Software/OctoBot-Services/tree/master/docs/CHANGELOG.md)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/31a1caa6e5384d80bf890dba5c9b5e4b)](https://app.codacy.com/gh/Drakkar-Software/OctoBot-Services?utm_source=github.com&utm_medium=referral&utm_content=Drakkar-Software/OctoBot-Services&utm_campaign=Badge_Grade_Dashboard)
 [![PyPI](https://img.shields.io/pypi/v/OctoBot-Services.svg)](https://pypi.python.org/pypi/OctoBot-Services/)
 [![Github-Action-CI](https://github.com/Drakkar-Software/OctoBot-Services/workflows/OctoBot-Services-CI/badge.svg)](https://github.com/Drakkar-Software/OctoBot-Services/actions)

--- a/octobot_services/__init__.py
+++ b/octobot_services/__init__.py
@@ -15,4 +15,4 @@
 #  License along with this library.
 
 PROJECT_NAME = "OctoBot-Services"
-VERSION = "1.2.15"  # major.minor.revision
+VERSION = "1.2.16"  # major.minor.revision

--- a/octobot_services/constants.py
+++ b/octobot_services/constants.py
@@ -37,6 +37,17 @@ CONFIG_GROUP_MESSAGE_DESCRIPTION = "group-message-description"
 CONFIG_USERNAMES_WHITELIST = "usernames-whitelist"
 CONFIG_CHAT_ID = "chat-id"
 
+CONFIG_TELEGRAM_API = "telegram-api"
+CONFIG_API = "telegram-api"
+CONFIG_API_HASH = "telegram-api-hash"
+CONFIG_TELEGRAM_PHONE = "telegram-phone"
+CONFIG_TELEGRAM_PASSWORD = "telegram-password"
+CONFIG_MESSAGE_CONTENT = "message-content"
+CONFIG_MESSAGE_SENDER = "message-sender"
+CONFIG_IS_GROUP_MESSAGE = "is-group-message"
+CONFIG_IS_CHANNEL_MESSAGE = "is-channel-message"
+CONFIG_IS_PRIVATE_MESSAGE = "is-private-message"
+
 # Web
 CONFIG_WEB = "web"
 CONFIG_WEB_IP = "ip"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ OctoBot-Trading>=1.12.0, <1.13
 praw==7.1.0
 # Telegram
 python-telegram-bot==13.1.0
+telethon==1.21.1
 # Twitter
 Python-Twitter==3.5
 # Google


### PR DESCRIPTION
Allow OctoBot to connect on user telegram account instead of using bot thanks to this we will be able to receive group, channel and private message in social evaluators.

Related to https://github.com/Drakkar-Software/OctoBot-Tentacles/pull/434